### PR TITLE
[WIP] Profilepage link screenname

### DIFF
--- a/qml/components/ProfileHeader.qml
+++ b/qml/components/ProfileHeader.qml
@@ -176,9 +176,16 @@ Item {
                 pixelSize: Theme.fontSizeSmall
                 bold: true
             }
-            color: Theme.primaryColor
+            color: Theme.hightlightColor
             elide: Text.ElideRight
             width: parent.width
+            MouseArea {
+                enabled: !profileItem.loadingError
+                anchors.fill: parent
+                onClicked: {
+                    pageStack.push(Qt.resolvedUrl("../pages/NewTweetPage.qml"), {"initialText": "@"+profileModel.screen_name});
+                }
+            }
         }
     }
 

--- a/qml/pages/NewTweetPage.qml
+++ b/qml/pages/NewTweetPage.qml
@@ -49,6 +49,7 @@ Page {
     property variant ipInfo;
     property variant place;
     property bool geoEnabled;
+    property alias initialText: enterTweetTextArea.text;
 
     function parseText(text) {
         var parsingResult = TwitterText.parseTweet(text);

--- a/rpm/harbour-piepmatz.spec
+++ b/rpm/harbour-piepmatz.spec
@@ -26,6 +26,9 @@ BuildRequires:  pkgconfig(sailfishapp) >= 1.0.2
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Quick)
+BuildRequires:  pkgconfig(Qt5DBus)
+BuildRequires:  pkgconfig(Qt5Positioning)
+BuildRequires:  pkgconfig(openssl)
 BuildRequires:  desktop-file-utils
 
 %description

--- a/rpm/harbour-piepmatz.yaml
+++ b/rpm/harbour-piepmatz.yaml
@@ -25,6 +25,9 @@ PkgConfigBR:
   - Qt5Core
   - Qt5Qml
   - Qt5Quick
+  - Qt5DBus
+  - Qt5Positioning
+  - openssl
 
 # Build dependencies without a pkgconfig setup can be listed here
 # PkgBR:


### PR DESCRIPTION
Makes the screen name on the profileHeader of the profilePage to open a new tweet with @profileModel.scree_name as initial text.
Also contains fixes for builds in a clean environment without dependencies preinstalled eg. build service.
